### PR TITLE
Add GIT_DEPLOY_REMOTE variable

### DIFF
--- a/git-deploy.sh
+++ b/git-deploy.sh
@@ -8,7 +8,7 @@ info(){
   echo -e "* \033[1m""$@""\033[0m"
 }
 
-REMOTE='origin'
+REMOTE=${GIT_DEPLOY_REMOTE:origin} # default remote is called "origin"
 ENV=${1:-dev} # first argument or default to dev
 
 # For local scripts before deploy (knock, for example)

--- a/git-deploy.sh
+++ b/git-deploy.sh
@@ -8,7 +8,7 @@ info(){
   echo -e "* \033[1m""$@""\033[0m"
 }
 
-REMOTE=${GIT_DEPLOY_REMOTE:origin} # default remote is called "origin"
+REMOTE=${GIT_DEPLOY_REMOTE:-origin} # default remote is called "origin"
 ENV=${1:-dev} # first argument or default to dev
 
 # For local scripts before deploy (knock, for example)


### PR DESCRIPTION
@LanF3usT Maintenant on devrait pouvoir ajouter `export GIT_DEPLOY_REMOTE="deploy"` dans son `~/.bash_profile` ou devant la commande git-deploy:

``` sh
$ GIT_DEPLOY_REMOTE=deploy git deploy prod
```

À tester.
